### PR TITLE
Add reusable enhanced EPUB builder skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ That's it. All skills and commands are now available in your Claude Code session
 
 This repository intentionally keeps the active skill surface capped below **100 discoverable `SKILL.md` files**. Older, narrower, duplicate, or project-specific skill packages are kept recoverable under [`archive/skills/`](archive/skills/) with `SKILL.archived.md` filenames so they do not load by default.
 
-The current active set has **88 discoverable `SKILL.md` files** after the follow-up pruning pass. Vesper app-focused skills live under [`vesper-app-skills/`](vesper-app-skills/) so they stay active while remaining grouped away from general-purpose skills.
+The current active set has **91 discoverable `SKILL.md` files**. Vesper app-focused skills live under [`vesper-app-skills/`](vesper-app-skills/) so they stay active while remaining grouped away from general-purpose skills.
 
 The active set and archive decisions are documented in the latest upkeep reports:
 

--- a/build-enhanced-epub/SKILL.md
+++ b/build-enhanced-epub/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: build-enhanced-epub
+description: Build reproducible, validated EPUB 3 books from authorized PDF, HTML, text, or chapter-file sources, with offline story-map navigation by arc, reading intent, character, location, faction, concept, and event. Use when Codex must ingest or normalize a long-form book, create a personal offline EPUB, recover chapter structure, add spoiler-friendly semantic indexes, build an Apple Books-compatible reading artifact, or audit and repair an existing enhanced-EPUB pipeline.
+---
+
+# Build Enhanced EPUB
+
+Create the book as a reproducible data pipeline, not a one-off scrape. Keep source
+content, normalized chapters, editorial indexes, EPUB generation, and QA separate.
+
+## Apply the rights gate
+
+Before downloading or copying substantial source content, establish that the user
+owns it, has permission, or is making a lawful personal copy. Require an explicit
+acknowledgement in automated download commands. Do not bypass DRM, authentication,
+paywalls, access controls, or technical restrictions. Do not publish source content.
+
+Keep downloaded books and chapter corpora out of shared skill repositories. Record
+source attribution and personal-use rights in EPUB metadata.
+
+## Choose the workflow
+
+1. Inspect the source and determine PDF text, scanned PDF/OCR, HTML chapters, plain
+   text, or existing structured files.
+2. Read [references/source-ingestion.md](references/source-ingestion.md) for the
+   selected source type.
+3. Normalize the result according to
+   [references/data-contracts.md](references/data-contracts.md).
+4. Audit the complete corpus before narrative analysis.
+5. If semantic navigation is requested, read
+   [references/editorial-indexing.md](references/editorial-indexing.md).
+6. Build EPUB structure according to
+   [references/epub3-layout.md](references/epub3-layout.md).
+7. Run every relevant check in
+   [references/qa-checklist.md](references/qa-checklist.md).
+
+For a large book and user-requested parallel work, read
+[references/collaboration.md](references/collaboration.md). Keep one orchestrator as
+the only writer of canonical IDs and merged indexes.
+
+## Establish the project contract
+
+Confirm or infer safely:
+
+- title, author, language, source URL/file, and intended output name;
+- user's rights acknowledgement and personal/shared distribution boundary;
+- expected chapter count when the source exposes one;
+- whether spoilers are allowed;
+- whether the user wants plain EPUB or enhanced semantic navigation.
+
+Create separate directories for `library/`, `analysis/`, `index/`, `src/`, `tests/`,
+`dist/`, and `docs/`. Cache the original source and extraction output so rebuilds do
+not repeatedly hit a website.
+
+## Ingest and normalize
+
+Preserve a stable `order` independent from source chapter IDs. Store one UTF-8 JSON
+file per chapter, zero-padded by reading order. Keep paragraph boundaries rather
+than flattening the chapter into one string.
+
+Repair structural source defects only when evidence is clear. Record every repair
+in metadata or QA notes. Never silently rewrite prose.
+
+Reject the corpus if chapter order is duplicated, discontinuous, unexpectedly
+short, empty, or polluted by table-of-contents/header/footer text. Run:
+
+```bash
+python3 scripts/audit_library.py /path/to/library
+```
+
+## Build evidence before interpretation
+
+Generate a corpus manifest, searchable JSONL, checksums, candidate proper nouns, and
+an explicit concordance for likely names. Use machine extraction only to locate
+evidence; do not promote candidates to canonical entities without editorial review.
+
+Inspect chapter text around every proposed arc boundary. Do not infer the story map
+from titles alone. Make summaries spoiler-aware or spoiler-complete according to the
+project contract.
+
+## Create the semantic layer
+
+Maintain four canonical documents: `arcs.json`, `entities.json`, `events.json`, and
+`intents.json`. Give every record a stable lowercase ASCII slug. Resolve aliases and
+renames before emitting cross-references.
+
+For long novels, target readable high-level stages rather than tiny plot beats. A
+novel over 400 chapters commonly needs 25–45 arcs and 75–150 reading intents. Scale
+down for shorter works. Every chapter must belong to an arc, and every destination
+must explain why the reader should jump there.
+
+Validate the index before building:
+
+```bash
+python3 scripts/validate_index.py /path/to/index /path/to/library
+```
+
+## Build EPUB 3
+
+Include cover, metadata, stylesheet, EPUB 3 navigation, NCX fallback, reading spine,
+and chapter XHTML. For enhanced books add these offline guide pages before chapters:
+
+- Start here
+- Story map
+- I want to reread…
+- Characters
+- Locations
+- Factions and concepts
+- Events
+
+Link guide records directly to chapter XHTML and link related records to one another.
+Do not use JavaScript or network dependencies in guide pages. Keep full chapter TOC
+nested behind a parent entry so the high-level map remains scannable in Apple Books.
+
+## Validate and deliver
+
+Build atomically to a temporary file, then replace the final EPUB. Run:
+
+```bash
+python3 scripts/validate_epub.py /path/to/book.epub
+```
+
+Also run EPUBCheck when Java and EPUBCheck are available. Test the target reader when
+possible. Report corpus counts, index counts, test results, file size, checksum,
+known source repairs, and any validation tool that could not run.
+
+Deliver the EPUB plus the reproducible project and QA report. Give short import
+instructions for the user's reader. Treat Apple Books or another EPUB reader as the
+offline app unless the user explicitly asks for a separate native application.

--- a/build-enhanced-epub/agents/openai.yaml
+++ b/build-enhanced-epub/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Build Enhanced EPUB"
+  short_description: "Build searchable offline EPUBs with story maps"
+  default_prompt: "Use $build-enhanced-epub to turn my authorized source into a validated offline EPUB with arc and intent navigation."

--- a/build-enhanced-epub/references/collaboration.md
+++ b/build-enhanced-epub/references/collaboration.md
@@ -1,0 +1,22 @@
+# Collaboration for large books
+
+Use parallel agents only when the user requests delegation or the active environment
+permits it. Keep tasks bounded and evidence-backed.
+
+Recommended split:
+
+1. Source engineer: inspect and normalize source.
+2. Corpus auditor: independently check completeness and extraction defects.
+3. Story workers: analyze non-overlapping chapter ranges with small boundary overlap.
+4. Canonical editor: merge arcs, aliases, entities, events, and intents.
+5. EPUB engineer: build package and navigation.
+6. QA worker: validate without seeing expected conclusions.
+
+The orchestrator owns the plan, shared schema, chapter-count contract, canonical ID
+namespace, merge, final validation, and delivery. Workers write drafts only. Never let
+two workers mutate the same canonical index or EPUB output concurrently.
+
+Give story workers local corpus artifacts, exact chapter ranges, required output
+schema, and a rule to cite chapter evidence. Include one or two boundary chapters from
+adjacent shards so transitions can be reconciled. Do not pass expected findings to an
+independent QA worker.

--- a/build-enhanced-epub/references/data-contracts.md
+++ b/build-enhanced-epub/references/data-contracts.md
@@ -1,0 +1,96 @@
+# Data contracts
+
+## Library layout
+
+```text
+library/<book-slug>/
+├── metadata.json
+├── cover.jpg
+├── source.*
+└── chapters/
+    ├── 0001.json
+    └── ...
+```
+
+## metadata.json
+
+Required fields:
+
+```json
+{
+  "title": "Book title",
+  "author": "Author",
+  "language": "vi",
+  "source_url": "https://example.test/book",
+  "cover_file": "cover.jpg",
+  "expected_chapters": 492,
+  "rights": "Personal offline copy; do not redistribute"
+}
+```
+
+Add source checksum, page count, extraction count, original title, and source file
+when available.
+
+## Chapter JSON
+
+```json
+{
+  "order": 1,
+  "chapter_id": "source-id-or-number",
+  "display_label": "Chương 1",
+  "title": "Chapter title",
+  "paragraphs": ["First paragraph.", "Second paragraph."],
+  "checksum_sha256": "...",
+  "source_url": "https://example.test/chapter/1",
+  "source_page_start": 10,
+  "source_page_end": 18,
+  "source_credit": "Source attribution"
+}
+```
+
+`order`, `chapter_id`, `display_label`, `title`, `paragraphs`, and checksum are the
+portable core. Source URL and PDF page fields are optional by source type.
+
+## Index documents
+
+Each document has `schema_version: 1` and one top-level array.
+
+### Arc
+
+Required: `id`, `title`, `summary`, `start_chapter`, `end_chapter`, `themes`,
+`search_terms`, `characters`, `locations`, `factions`, `key_chapters`.
+
+Each key chapter has `chapter`, `label`, and `reason`.
+
+### Entity
+
+Required: `id`, `name`, `type`, `aliases`, `summary`, `first_chapter`, `arc_ids`,
+`important_ranges`, `related_entities`.
+
+Entity type is one of `character`, `location`, `faction`, `concept`. Each important
+range has `start`, `end`, and `label`.
+
+### Event
+
+Required: `id`, `title`, `summary`, `start_chapter`, `end_chapter`, `peak_chapter`,
+`arc_ids`, `participants`, `locations`, `search_terms`.
+
+### Intent
+
+Required: `id`, `category`, `title`, `description`, `search_terms`, `destinations`.
+Each destination has `chapter`, optional `end_chapter`, `label`, `reason`, `priority`,
+and `arc_id`.
+
+Recommended categories:
+
+- Identity and mysteries
+- Characters and relationships
+- Eras and history
+- Places and journeys
+- Battles and confrontations
+- Reform, cultivation, and power
+- Revelations and reversals
+- Ending and extras
+
+Localize category display strings to the book language, but keep them consistent
+within the project.

--- a/build-enhanced-epub/references/editorial-indexing.md
+++ b/build-enhanced-epub/references/editorial-indexing.md
@@ -1,0 +1,57 @@
+# Editorial semantic indexing
+
+## Evidence artifacts
+
+Create these before assigning narrative meaning:
+
+- corpus manifest with title, length, paragraph count, checksum per chapter;
+- JSONL containing order, title, and plain text;
+- proper-noun candidates with chapter frequency;
+- concordance for known names, aliases, factions, and places;
+- boundary samples containing the end of one proposed arc and start of the next.
+
+Machine candidates are evidence locators, not canonical facts.
+
+## Arc method
+
+1. Read the full chapter-title sequence for orientation.
+2. Propose high-level continuous ranges.
+3. Inspect chapter text on both sides of every boundary.
+4. Write one summary describing setup, development, and the transition to the next arc.
+5. Select at least three useful entry chapters for a long arc: setup, turn, climax.
+6. Ensure ranges cover chapter `1..N` exactly once with no gaps or overlaps.
+
+Favor a small number of memorable story stages over chapter-sized pseudo-arcs.
+
+## Entity method
+
+Merge aliases, honorifics, translated spellings, secret identities, and renamed
+personas before minting IDs. Keep separate entities separate when the text treats them
+as distinct people despite shared titles. Compute textual ranges, then editorially
+remove ordinary-language homonyms and prophecy-only false prominence.
+
+Summaries should answer who/what the entity is and why a returning reader cares.
+
+## Event method
+
+Use an event range wide enough to include necessary setup. Mark a peak chapter, not
+merely the first title containing the event name. Include participants and locations
+only when the text supports them.
+
+## Intent method
+
+Write intents as remembered questions or desires, for example:
+
+- “I want to reread when the protagonist first meets X.”
+- “Where is the truth about Y revealed?”
+- “Start the campaign at Z with enough context.”
+- “Show me the final battle and immediate aftermath.”
+
+Give one to six ranked destinations. Explain why each destination is useful and start
+one chapter earlier when context materially improves the reading experience.
+
+## Canonical merge
+
+Only one process writes canonical JSON. Draft workers may use local IDs, but the merge
+step must deduplicate names, mint final IDs, rewrite all references, validate ranges,
+and reject unknown references. Preserve drafts as evidence, not as runtime indexes.

--- a/build-enhanced-epub/references/epub3-layout.md
+++ b/build-enhanced-epub/references/epub3-layout.md
@@ -1,0 +1,54 @@
+# EPUB 3 layout
+
+## ZIP invariants
+
+- First entry: `mimetype`.
+- Exact content: `application/epub+zip`.
+- Store it uncompressed.
+- Include `META-INF/container.xml` pointing to the OPF.
+
+## Recommended package
+
+```text
+OEBPS/
+├── content.opf
+├── nav.xhtml
+├── toc.ncx
+├── cover.xhtml
+├── images/cover.jpg
+├── styles/book.css
+├── guide/
+│   ├── start.xhtml
+│   ├── story-map.xhtml
+│   ├── intents.xhtml
+│   ├── characters.xhtml
+│   ├── locations.xhtml
+│   ├── factions-concepts.xhtml
+│   └── events.xhtml
+└── text/chapter-0001.xhtml
+```
+
+## Metadata
+
+Include stable identifier, title, creator, language, source, modification timestamp,
+cover, and rights statement. Derive a deterministic UUID from a stable source key if
+the source has no ISBN or canonical identifier.
+
+## Navigation
+
+Place Start, Story Map, Intent index, and lookup pages before the full chapter list.
+Nest arcs below Story Map and chapters below “All chapters.” Include NCX for older
+readers. Add the guide pages to the spine before chapters; make `nav.xhtml` a legal
+non-linear spine target when guide pages link to it.
+
+## XHTML and CSS
+
+Generate XML-safe XHTML with language metadata and no script. Escape text and remove
+XML 1.0 control characters. Use relative links. Give every semantic record a stable
+anchor ID. Keep styling typographic and reader-friendly; do not force colors that
+break dark mode. Avoid fixed layouts for prose books.
+
+## Atomic build
+
+Write to a temporary file in the destination directory, validate it, then rename it
+to the final path. This prevents a failed build from replacing a known-good EPUB.

--- a/build-enhanced-epub/references/qa-checklist.md
+++ b/build-enhanced-epub/references/qa-checklist.md
@@ -1,0 +1,49 @@
+# QA checklist
+
+## Source and corpus
+
+- Verify source signature, checksum, page/response count, and extraction encoding.
+- Verify chapter orders are unique and exactly continuous.
+- Compare detected count with expected count.
+- Flag empty or unusually short chapters.
+- Detect duplicate content checksums.
+- Search for TOC, site chrome, header/footer, OCR, and encoding leakage.
+- Inspect first, middle, repaired, and final chapters manually.
+- Record every source repair.
+
+## Semantic index
+
+- Validate JSON syntax and schema version.
+- Validate unique ASCII slug IDs.
+- Validate chapter and range bounds.
+- Cover all chapters by arcs without gaps or overlaps.
+- Resolve every cross-reference.
+- Keep destination priorities unique per intent.
+- Ensure every intent has search terms, a reason, and a valid arc.
+- Spot-check arc boundaries against chapter prose.
+- Spot-check aliases and false-positive homonyms.
+
+## EPUB package
+
+- Check uncompressed first `mimetype` entry.
+- Parse all XML, OPF, NCX, and XHTML.
+- Verify every manifest, spine, href, src, and fragment target.
+- Verify one EPUB 3 nav document and a non-empty NCX.
+- Verify cover declaration and media type.
+- Verify chapter and guide counts.
+- Reject duplicate ZIP entries.
+- Reject network URLs, scripts, and event handlers from offline guide pages.
+- Run EPUBCheck when available.
+- Open on the target reader and test navigation, font resizing, dark mode, search,
+  bookmarks, and at least five deep links.
+
+## Regression tests
+
+Test heading parsing, malformed known headings, TOC exclusion, cross-page paragraph
+joining, index coverage, category coverage, EPUB ZIP invariants, and link validation.
+
+## Handoff report
+
+Report chapter/page/paragraph/character counts, number of arcs/entities/events/intents,
+test totals, validator results, file size, SHA-256, repairs, tool limitations, and
+personal-use restriction.

--- a/build-enhanced-epub/references/source-ingestion.md
+++ b/build-enhanced-epub/references/source-ingestion.md
@@ -1,0 +1,47 @@
+# Source ingestion
+
+## PDF with embedded text
+
+1. Inspect metadata, encryption, page count, fonts, and extractability.
+2. Use Poppler `pdftotext -layout` to preserve useful page structure.
+3. Split on form-feed so source-page provenance remains available.
+4. Detect chapter headings only in the content region. Exclude TOC pages.
+5. Join paragraph fragments across page breaks conservatively.
+6. Render the first page with `pdftoppm` for the cover when appropriate.
+
+Use the PDF skill when visual layout or OCR quality must be inspected. Compare a
+sample of extracted pages with rendered images before trusting a heading regex.
+
+## Scanned PDF
+
+Render pages, OCR with the appropriate language model, retain confidence or audit
+samples, and never claim exact text fidelity without spot checks. Separate OCR output
+from the original scan. Prefer manual correction of headings before prose cleanup.
+
+## HTML chapter site
+
+Inspect the viewer and network-visible page structure before writing a crawler.
+Prefer stable chapter IDs or canonical URLs over visible next/previous labels. Cache
+each fetched response. Use a descriptive user agent, rate limiting, retry/backoff,
+and resume support. Stop if access controls, robots policy, or site terms prohibit
+the intended collection.
+
+Extract only title and chapter body. Remove navigation, ads, comments, breadcrumbs,
+and repeated headers using source-specific selectors. Preserve source URL per chapter.
+
+Use browser control only when interactive inspection or an existing authorized login
+is required. Do not automate around CAPTCHAs or anti-bot controls.
+
+## Plain text or structured files
+
+Detect encoding, normalize line endings, and identify chapter boundaries without
+destroying paragraph breaks. If filenames determine order, parse order explicitly and
+reject ambiguous lexical sorting such as `1, 10, 2`.
+
+## Download safety
+
+- Require an explicit rights acknowledgement flag for commands that download a book.
+- Download to a temporary file, verify media signature and plausible size, then rename.
+- Compute SHA-256 of the source.
+- Avoid downloading again when a verified cache exists.
+- Store credentials outside the project and never emit them in logs.

--- a/build-enhanced-epub/scripts/audit_library.py
+++ b/build-enhanced-epub/scripts/audit_library.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Audit a normalized enhanced-EPUB library without third-party dependencies."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+def audit(library: Path) -> dict:
+    chapter_dir = library / "chapters"
+    paths = sorted(chapter_dir.glob("*.json"))
+    errors, warnings, chapters, checksums = [], [], [], []
+    for path in paths:
+        try:
+            item = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            errors.append(f"{path.name}: invalid JSON/UTF-8: {exc}")
+            continue
+        order = item.get("order")
+        paragraphs = item.get("paragraphs")
+        if isinstance(order, bool) or not isinstance(order, int):
+            errors.append(f"{path.name}: order must be an integer")
+            continue
+        if not isinstance(paragraphs, list) or not all(isinstance(x, str) for x in paragraphs):
+            errors.append(f"{path.name}: paragraphs must be an array of strings")
+            continue
+        text = "\n\n".join(x.strip() for x in paragraphs if x.strip())
+        if not text:
+            errors.append(f"{path.name}: empty chapter")
+        checksum = hashlib.sha256(text.encode()).hexdigest()
+        declared = item.get("checksum_sha256")
+        if declared and declared != checksum:
+            errors.append(f"{path.name}: checksum mismatch")
+        if len(text) < 1000:
+            warnings.append(f"{path.name}: unusually short ({len(text)} chars)")
+        chapters.append((order, path.name, len(paragraphs), len(text)))
+        checksums.append((checksum, order))
+
+    orders = [x[0] for x in chapters]
+    expected = list(range(1, len(chapters) + 1))
+    if orders != expected:
+        errors.append("chapter order is not exactly continuous 1..N in filename order")
+    if len(orders) != len(set(orders)):
+        errors.append("duplicate chapter order")
+    duplicate_content = {key: values for key, values in _group(checksums).items() if len(values) > 1}
+    if duplicate_content:
+        errors.append(f"duplicate content checksums: {duplicate_content}")
+
+    metadata = {}
+    metadata_path = library / "metadata.json"
+    if metadata_path.exists():
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            errors.append(f"metadata.json: {exc}")
+    else:
+        errors.append("missing metadata.json")
+    declared_count = metadata.get("expected_chapters")
+    if declared_count is not None and declared_count != len(chapters):
+        errors.append(f"expected_chapters={declared_count}, found={len(chapters)}")
+
+    lengths = [x[3] for x in chapters]
+    paragraph_counts = [x[2] for x in chapters]
+    return {
+        "valid": not errors,
+        "library": str(library.resolve()),
+        "chapter_count": len(chapters),
+        "orders": {"first": min(orders) if orders else None, "last": max(orders) if orders else None},
+        "characters": _summary(lengths),
+        "paragraphs": {**_summary(paragraph_counts), "total": sum(paragraph_counts)},
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+def _group(items):
+    grouped = {}
+    for key, value in items:
+        grouped.setdefault(key, []).append(value)
+    return grouped
+
+
+def _summary(values):
+    if not values:
+        return {"min": None, "median": None, "max": None, "total": 0}
+    return {"min": min(values), "median": statistics.median(values),
+            "max": max(values), "total": sum(values)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("library", type=Path)
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args()
+    result = audit(args.library)
+    output = json.dumps(result, ensure_ascii=False, indent=2) + "\n"
+    if args.report:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(output, encoding="utf-8")
+    sys.stdout.write(output)
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build-enhanced-epub/scripts/validate_epub.py
+++ b/build-enhanced-epub/scripts/validate_epub.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Deep structural/link validation for an offline EPUB package."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import posixpath
+import sys
+import zipfile
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+from xml.etree import ElementTree as ET
+
+
+def local_name(tag): return tag.rsplit("}", 1)[-1]
+
+
+def validate(path: Path) -> dict:
+    errors = []
+    try:
+        archive = zipfile.ZipFile(path)
+    except Exception as exc:
+        return {"valid": False, "errors": [f"cannot open ZIP: {exc}"]}
+    with archive:
+        infos, names = archive.infolist(), archive.namelist()
+        if not infos or infos[0].filename != "mimetype": errors.append("mimetype must be first")
+        elif infos[0].compress_type != zipfile.ZIP_STORED: errors.append("mimetype must be uncompressed")
+        if len(names) != len(set(names)): errors.append("duplicate ZIP entry")
+        if "mimetype" not in names or archive.read("mimetype") != b"application/epub+zip": errors.append("invalid mimetype")
+        required = {"META-INF/container.xml"}
+        for item in required - set(names): errors.append(f"missing {item}")
+        roots = {}
+        for name in names:
+            if name.endswith((".xml", ".opf", ".ncx", ".xhtml")):
+                try: roots[name] = ET.fromstring(archive.read(name))
+                except Exception as exc: errors.append(f"invalid XML {name}: {exc}")
+        opf_names = [name for name in roots if name.endswith(".opf")]
+        if len(opf_names) != 1: errors.append(f"expected one OPF, found {len(opf_names)}")
+        name_set = set(names)
+        ids = {name: {node.attrib["id"] for node in root.iter() if "id" in node.attrib}
+               for name, root in roots.items()}
+        for name, root in roots.items():
+            is_guide = "/guide/" in name
+            if is_guide and any(local_name(node.tag).lower() == "script" for node in root.iter()): errors.append(f"script in guide {name}")
+            for node in root.iter():
+                if is_guide and any(key.lower().startswith("on") for key in node.attrib): errors.append(f"event handler in guide {name}")
+                for attribute in ("href", "src"):
+                    raw = node.attrib.get(attribute)
+                    if not raw: continue
+                    target = urlsplit(raw)
+                    if target.scheme or target.netloc:
+                        if is_guide: errors.append(f"network URL in guide {name}: {raw}")
+                        continue
+                    resource = unquote(target.path)
+                    resolved = posixpath.normpath(posixpath.join(posixpath.dirname(name), resource))
+                    if resource and resolved not in name_set: errors.append(f"missing target in {name}: {raw}")
+                    anchor_doc = resolved if resource else name
+                    if target.fragment and target.fragment not in ids.get(anchor_doc, set()): errors.append(f"missing anchor in {name}: {raw}")
+        if len(opf_names) == 1:
+            opf = roots[opf_names[0]]
+            manifest_nodes = [node for node in opf.iter() if local_name(node.tag) == "item"]
+            manifest = {node.attrib.get("id"): node for node in manifest_nodes}
+            if None in manifest or len(manifest) != len(manifest_nodes): errors.append("duplicate/empty manifest id")
+            navs = [node for node in manifest_nodes if "nav" in node.attrib.get("properties", "").split()]
+            if len(navs) != 1: errors.append("expected exactly one nav manifest item")
+            opf_dir = posixpath.dirname(opf_names[0])
+            for node in manifest_nodes:
+                href = node.attrib.get("href")
+                if not href or posixpath.normpath(posixpath.join(opf_dir, href)) not in name_set: errors.append(f"manifest target missing: {href}")
+            spine_ids = [node.attrib.get("idref") for node in opf.iter() if local_name(node.tag) == "itemref"]
+            for ident in spine_ids:
+                if ident not in manifest: errors.append(f"unknown spine idref: {ident}")
+        ncx = [root for name, root in roots.items() if name.endswith(".ncx")]
+        if not ncx or not any(local_name(node.tag) == "navPoint" for root in ncx for node in root.iter()): errors.append("missing/non-functional NCX")
+        return {"valid": not errors, "file": str(path.resolve()), "entries": len(names),
+                "xml_documents": len(roots), "errors": errors}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(); parser.add_argument("epub", type=Path); parser.add_argument("--report", type=Path)
+    args = parser.parse_args(); result = validate(args.epub)
+    output = json.dumps(result, ensure_ascii=False, indent=2) + "\n"
+    if args.report: args.report.parent.mkdir(parents=True, exist_ok=True); args.report.write_text(output, encoding="utf-8")
+    sys.stdout.write(output); return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__": raise SystemExit(main())

--- a/build-enhanced-epub/scripts/validate_index.py
+++ b/build-enhanced-epub/scripts/validate_index.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Validate canonical semantic indexes against normalized chapter JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+FILES = {"arcs": "arcs.json", "entities": "entities.json",
+         "events": "events.json", "intents": "intents.json"}
+
+
+class Validator:
+    def __init__(self, total):
+        self.total, self.errors, self.warnings = total, [], []
+
+    def error(self, path, message): self.errors.append(f"{path}: {message}")
+    def chapter(self, value, path):
+        if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= self.total:
+            self.error(path, f"must be an integer in 1..{self.total}")
+            return None
+        return value
+    def text(self, item, key, path):
+        value = item.get(key)
+        if not isinstance(value, str) or not value.strip(): self.error(f"{path}.{key}", "must be non-empty text")
+    def refs(self, values, allowed, path):
+        if not isinstance(values, list): self.error(path, "must be an array"); return
+        if len(values) != len(set(x for x in values if isinstance(x, str))): self.error(path, "duplicate reference")
+        for i, value in enumerate(values):
+            if value not in allowed: self.error(f"{path}[{i}]", f"unknown reference {value!r}")
+
+
+def load_document(directory, kind, errors):
+    path = directory / FILES[kind]
+    try: doc = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc: errors.append(f"{path.name}: {exc}"); return []
+    if not isinstance(doc, dict) or doc.get("schema_version") != 1:
+        errors.append(f"{path.name}: schema_version must be 1"); return []
+    records = doc.get(kind)
+    if not isinstance(records, list): errors.append(f"{path.name}.{kind}: must be an array"); return []
+    return records
+
+
+def validate(index_dir: Path, library: Path) -> dict:
+    chapter_paths = sorted((library / "chapters").glob("*.json"))
+    orders = []
+    for path in chapter_paths:
+        try: orders.append(json.loads(path.read_text(encoding="utf-8"))["order"])
+        except Exception: pass
+    preliminary = []
+    if orders != list(range(1, len(orders) + 1)): preliminary.append("library chapters are not continuous 1..N")
+    v = Validator(len(orders))
+    v.errors.extend(preliminary)
+    documents = {kind: load_document(index_dir, kind, v.errors) for kind in FILES}
+    ids = {}
+    for kind, records in documents.items():
+        seen = set()
+        for i, item in enumerate(records):
+            path = f"{kind}[{i}]"
+            if not isinstance(item, dict): v.error(path, "must be an object"); continue
+            ident = item.get("id")
+            if not isinstance(ident, str) or not ID_RE.fullmatch(ident): v.error(f"{path}.id", "invalid ASCII slug")
+            elif ident in seen: v.error(f"{path}.id", "duplicate id")
+            else: seen.add(ident)
+        ids[kind] = seen
+
+    covered = []
+    for i, arc in enumerate(documents["arcs"]):
+        if not isinstance(arc, dict): continue
+        path = f"arcs[{i}]"; v.text(arc, "title", path); v.text(arc, "summary", path)
+        start = v.chapter(arc.get("start_chapter"), f"{path}.start_chapter")
+        end = v.chapter(arc.get("end_chapter"), f"{path}.end_chapter")
+        if start and end:
+            if start > end: v.error(path, "start exceeds end")
+            else: covered.extend(range(start, end + 1))
+        for field in ("themes", "search_terms"):
+            if not isinstance(arc.get(field), list) or not arc[field]: v.error(f"{path}.{field}", "must be a non-empty array")
+        for field in ("characters", "locations", "factions"): v.refs(arc.get(field), ids["entities"], f"{path}.{field}")
+        keys = arc.get("key_chapters")
+        if not isinstance(keys, list) or not keys: v.error(f"{path}.key_chapters", "must be a non-empty array"); continue
+        for j, key in enumerate(keys):
+            kp = f"{path}.key_chapters[{j}]"
+            if not isinstance(key, dict): v.error(kp, "must be an object"); continue
+            chapter = v.chapter(key.get("chapter"), f"{kp}.chapter")
+            v.text(key, "label", kp); v.text(key, "reason", kp)
+            if chapter and start and end and not start <= chapter <= end: v.error(f"{kp}.chapter", "outside arc")
+    if covered != list(range(1, v.total + 1)): v.error("arcs", "must cover 1..N exactly once in order")
+
+    for i, entity in enumerate(documents["entities"]):
+        if not isinstance(entity, dict): continue
+        path = f"entities[{i}]"
+        for key in ("name", "summary", "type"): v.text(entity, key, path)
+        if entity.get("type") not in {"character", "location", "faction", "concept"}: v.error(f"{path}.type", "invalid type")
+        v.chapter(entity.get("first_chapter"), f"{path}.first_chapter")
+        v.refs(entity.get("arc_ids"), ids["arcs"], f"{path}.arc_ids")
+        v.refs(entity.get("related_entities"), ids["entities"], f"{path}.related_entities")
+        ranges = entity.get("important_ranges")
+        if not isinstance(ranges, list) or not ranges: v.error(f"{path}.important_ranges", "must be non-empty"); continue
+        for j, item in enumerate(ranges):
+            rp = f"{path}.important_ranges[{j}]"
+            if not isinstance(item, dict): v.error(rp, "must be an object"); continue
+            start = v.chapter(item.get("start"), f"{rp}.start"); end = v.chapter(item.get("end"), f"{rp}.end")
+            v.text(item, "label", rp)
+            if start and end and start > end: v.error(rp, "start exceeds end")
+
+    for i, event in enumerate(documents["events"]):
+        if not isinstance(event, dict): continue
+        path = f"events[{i}]"; v.text(event, "title", path); v.text(event, "summary", path)
+        start = v.chapter(event.get("start_chapter"), f"{path}.start_chapter")
+        end = v.chapter(event.get("end_chapter"), f"{path}.end_chapter")
+        peak = v.chapter(event.get("peak_chapter"), f"{path}.peak_chapter")
+        if start and end and peak and not start <= peak <= end: v.error(f"{path}.peak_chapter", "outside event")
+        v.refs(event.get("arc_ids"), ids["arcs"], f"{path}.arc_ids")
+        v.refs(event.get("participants"), ids["entities"], f"{path}.participants")
+        v.refs(event.get("locations"), ids["entities"], f"{path}.locations")
+
+    for i, intent in enumerate(documents["intents"]):
+        if not isinstance(intent, dict): continue
+        path = f"intents[{i}]"
+        for key in ("title", "description", "category"): v.text(intent, key, path)
+        terms = intent.get("search_terms")
+        if not isinstance(terms, list) or not terms: v.error(f"{path}.search_terms", "must be non-empty")
+        destinations = intent.get("destinations")
+        if not isinstance(destinations, list) or not 1 <= len(destinations) <= 6:
+            v.error(f"{path}.destinations", "must contain 1..6 items"); continue
+        priorities = []
+        for j, dest in enumerate(destinations):
+            dp = f"{path}.destinations[{j}]"
+            if not isinstance(dest, dict): v.error(dp, "must be an object"); continue
+            start = v.chapter(dest.get("chapter"), f"{dp}.chapter")
+            end = dest.get("end_chapter", start)
+            end = v.chapter(end, f"{dp}.end_chapter")
+            if start and end and start > end: v.error(dp, "start exceeds end")
+            v.text(dest, "label", dp); v.text(dest, "reason", dp)
+            priority = dest.get("priority")
+            if isinstance(priority, bool) or not isinstance(priority, int) or priority < 1: v.error(f"{dp}.priority", "must be positive integer")
+            else: priorities.append(priority)
+            if dest.get("arc_id") not in ids["arcs"]: v.error(f"{dp}.arc_id", "unknown arc")
+        if len(priorities) != len(set(priorities)): v.error(f"{path}.destinations", "duplicate priority")
+
+    return {"valid": not v.errors, "chapter_count": v.total,
+            "counts": {kind: len(records) for kind, records in documents.items()},
+            "errors": v.errors, "warnings": v.warnings}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(); parser.add_argument("index", type=Path); parser.add_argument("library", type=Path); parser.add_argument("--report", type=Path)
+    args = parser.parse_args(); result = validate(args.index, args.library)
+    output = json.dumps(result, ensure_ascii=False, indent=2) + "\n"
+    if args.report: args.report.parent.mkdir(parents=True, exist_ok=True); args.report.write_text(output, encoding="utf-8")
+    sys.stdout.write(output); return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__": raise SystemExit(main())


### PR DESCRIPTION
## What changed

- adds the `build-enhanced-epub` skill for authorized PDF, HTML, text, and chapter-file sources
- documents reproducible ingestion, semantic indexing, EPUB 3 navigation, multi-agent merge discipline, and QA
- adds standalone corpus, canonical-index, and EPUB validators
- updates the discoverable skill count

## Why

The workflow used to create spoiler-friendly offline EPUBs is now reusable without including any copyrighted book corpus or personal project data.

## Validation

- skill creator `quick_validate.py`: passed
- Python compilation: passed
- corpus audit against a 492-chapter project: passed
- semantic index validation (25 arcs, 69 entities, 75 events, 100 intents): passed
- deep EPUB validation (507 ZIP entries): passed
- source and repository skill directories diff clean after sync
