### PR TITLE
Add monkey-test fleet orchestration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ That's it. All skills and commands are now available in your Claude Code session
 
 This repository intentionally keeps the active skill surface close to **100 discoverable `SKILL.md` files**. Older, narrower, duplicate, or project-specific skill packages are kept recoverable under [`archive/skills/`](archive/skills/) with `SKILL.archived.md` filenames so they do not load by default.
 
-The current active set has **113 discoverable `SKILL.md` files**. Vesper app-focused skills live under [`vesper-app-skills/`](vesper-app-skills/) so they stay active while remaining grouped away from general-purpose skills.
+The current active set has **114 discoverable `SKILL.md` files**. Vesper app-focused skills live under [`vesper-app-skills/`](vesper-app-skills/) so they stay active while remaining grouped away from general-purpose skills.
 
 The active set and archive decisions are documented in the latest upkeep reports:
 

--- a/run-monkey-test-fleet/SKILL.md
+++ b/run-monkey-test-fleet/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: run-monkey-test-fleet
+description: Orchestrate a fleet of implementation, specification-review, engineering-review, integration, and final-audit agents to turn monkey-test dossiers, adversarial QA reports, audit findings, bug backlogs, or release blockers into integrated, evidence-backed fixes. Use when Codex must coordinate many findings across a repository, parallelize non-overlapping work safely, preserve concurrent user changes and live systems, independently verify every issue, resolve cross-track regressions, and report exact completed, partial, blocked, residual, and operationally unmeasured results.
+---
+
+# Run Monkey-Test Fleet
+
+Convert a findings dossier into a controlled remediation program. Remain the root orchestrator: own scope, state, integration, verification, safety, and reporting; delegate bounded implementation and independent review work.
+
+## Load the operating references
+
+Read these files before spawning agents:
+
+- [references/orchestration-contract.md](references/orchestration-contract.md) for roles, prompt contracts, fleet sizing, and review independence.
+- [references/ledger-schema.md](references/ledger-schema.md) for the issue/run state machines and evidence requirements.
+- [references/acceptance-gates.md](references/acceptance-gates.md) for per-lane, integration, release, runtime, and reporting gates.
+- [references/failure-playbook.md](references/failure-playbook.md) when the worktree is dirty, models fail, agents under-deliver, branches collide, specifications appear late, live processes exist, or `main` moves during the run.
+
+Initialize and validate the run ledger with `scripts/fleet_ledger.py`. Keep it in the target repository under `.codex/fleet-runs/<run-id>/` unless repository instructions require another location.
+
+## Non-negotiable invariants
+
+1. Treat tests as evidence, not proof of issue closure.
+2. Never let an implementation owner approve its own work.
+3. Require both specification and engineering review for every implementation lane.
+4. Integrate semantically; never choose a branch wholesale when that would discard valid concurrent work.
+5. Preserve user changes, untracked files, dirty worktrees, committed concurrent work, and live data.
+6. Do not restart, deploy, migrate, publish, or mutate a live system unless the user authorized that action and a read-only safety check proves the target.
+7. Report model/tool substitutions exactly. Never imply an unavailable named model or reviewer ran.
+8. Keep one authoritative ledger. Do not infer status from chat history alone.
+9. Mark an issue `cleared` only when its acceptance criteria, tests, independent reviews, integration evidence, and documentation are complete.
+10. Keep roadmap items, production measurements, deployment, and residual risks explicit. Do not convert them into success by wording.
+
+## Phase 0: Establish authority and repository truth
+
+Before delegation:
+
+1. Read the complete findings dossier, every applicable `AGENTS.md`, repository specification, approved brief, release checklist, and linked document needed to interpret acceptance.
+2. Follow repository discovery instructions. Prefer code-graph tools when required; fall back to text search only for unsupported or non-code discovery.
+3. Inspect branch, worktree status, untracked files, running processes, active jobs, configured runtimes, package manager, and test commands using read-only operations.
+4. Identify what the user authorized: diagnosis, code changes, live verification, deployment, or monitoring. Do not broaden authority.
+5. Record the exact starting revision, baseline commands, relevant live processes, dirty paths, protected paths, and known concurrent owners.
+6. Run the smallest credible baseline quality matrix. If it fails, classify failures as pre-existing, environmental, or dossier-related; do not silently inherit them.
+
+Initialize the ledger:
+
+```bash
+python3 <skill-dir>/scripts/fleet_ledger.py init \
+  --run-dir .codex/fleet-runs/<run-id> \
+  --repo-root "$PWD" \
+  --dossier <path-to-dossier> \
+  --base-revision <exact-revision>
+```
+
+Populate every finding before spawning implementation agents. Split compound findings when their acceptance or ownership differs. Add discovered requirements rather than hiding them under an existing ID.
+
+## Phase 1: Normalize findings into contracts
+
+For every issue, record:
+
+- Stable ID and concise title.
+- Exact source location and verbatim intent as a short paraphrase.
+- Severity and release impact.
+- Observable reproduction or proof gap.
+- Acceptance criteria that can return `pass`, `fail`, or `unmeasured`.
+- Likely code ownership and shared integration surfaces.
+- Required unit, integration, security, accessibility, browser, concurrency, crash-recovery, packaging, and live proofs.
+- Dependencies, conflicts, and explicit non-goals.
+- Whether the issue is code-closable, operational, roadmap, or production-measurement work.
+
+Reject vague criteria such as “works,” “secure,” or “tested.” Require observable outcomes and forbidden outcomes.
+
+## Phase 2: Design the fleet
+
+Partition by ownership and integration surface, not by equal issue counts. A lane may own several related issues when that reduces collisions. Keep these roles separate:
+
+- **Implementation owners:** reproduce, test, implement, document, and commit bounded issue groups.
+- **Specification reviewers:** verify the exact dossier/spec acceptance contract and identify missing product behavior.
+- **Engineering reviewers:** inspect correctness, security, privacy, durability, concurrency, maintainability, type safety, and regression risk.
+- **Integration owners:** reconcile known overlapping branches in an isolated integration worktree without dropping either contract.
+- **Final whole-branch auditors:** review the exact integrated revision, including cross-lane behavior no isolated branch could expose.
+- **Runtime verifier:** perform authorized browser/API/MCP/process probes only after code clearance and safe deployment.
+
+Use isolated worktrees and branches for concurrent code owners when Git is available. Give every agent explicit ownership, exact paths/revisions, commands, acceptance IDs, and the instruction that other agents share the repository and their edits must not be reverted.
+
+Use the collaboration tools to spawn agents because invoking this skill explicitly authorizes the fleet topology. Do not exhaust every slot immediately. Reserve capacity for rework, semantic merges, and independent final reviewers. Prefer one agent per cohesive ownership lane; add advisers only for genuinely independent surfaces.
+
+Do not force requested model names without verifying support. If a requested model is unavailable, report the failure once, select the strongest callable suitable model, and keep reviewer independence through separate agents and prompts.
+
+## Phase 3: Dispatch implementation waves
+
+Before each spawn:
+
+1. Create or identify the agent’s isolated worktree and branch.
+2. Record its issue IDs, owned files/modules, base revision, and required gates.
+3. Include exact dossier/spec paths rather than a summary alone.
+4. Require the agent to inspect repository instructions and baseline its lane.
+5. Require regression tests that fail before the fix when practical.
+6. Require a commit, changed-file list, commands/results, residuals, and integration notes.
+7. Forbid live-data mutation and unrelated cleanup.
+
+Dispatch independent lanes concurrently. Keep cross-cutting shared surfaces—central routers, CLI entry points, canonical models, schemas, migration code, global styles, and release configuration—under explicit integration control.
+
+While agents run:
+
+- Send the user concise progress updates at meaningful milestones and at least once per minute during long work.
+- Poll agent state without busy-waiting.
+- Inspect actual branches/diffs, not only agent prose.
+- Correct wrong worktrees, wrong interpreters, unsupported models, scope drift, or memo-only “implementations” immediately.
+- Record new findings and cross-lane dependencies in the ledger.
+
+## Phase 4: Review every lane twice
+
+Start reviews only from an exact commit. Give reviewers the raw dossier/spec, branch/revision, diff, and test surface; do not leak the intended verdict or prior reviewer conclusions.
+
+Run two independent axes:
+
+1. **Specification review:** determine whether every assigned issue is fully, partially, or not satisfied; reproduce important claims; identify missing UX/API/state-machine behavior and undocumented scope.
+2. **Engineering review:** search for correctness, security, privacy, atomicity, race, crash-consistency, stale-worker, path, lease, type, migration, accessibility, and maintainability failures.
+
+A reviewer must return structured findings with severity, issue ID, file/function, reproduction or reasoning, required correction, and verdict. “Looks good” without inspected evidence is not clearance.
+
+On any hard finding:
+
+1. Move the lane to `rework`.
+2. Return concrete reproduction and acceptance criteria to the implementation owner.
+3. Re-review the delta with both axes when the change can affect both.
+4. Never self-certify a fix because the suite is green.
+
+## Phase 5: Integrate in dependency order
+
+Create one isolated integration branch from the protected base. Integrate cleared lanes in dependency order:
+
+1. Canonical data contracts and migrations.
+2. Durability, transaction, policy, and security primitives.
+3. Domain services and workers.
+4. Search/projection and derived indexes.
+5. HTTP/MCP/CLI surfaces.
+6. UI/accessibility.
+7. QA tooling, packaging, and documentation.
+
+After each meaningful wave:
+
+- Resolve conflicts semantically, preserving both reviewed contracts.
+- Run focused combined tests for the merged surfaces.
+- Run the growing full suite when practical.
+- Check that concurrent `main` or protected-branch work has not advanced.
+- Update the ledger with the integration commit and evidence.
+
+If `main` advances, merge only committed work into the integration branch and re-run gates. Preserve unrelated uncommitted work untouched. Never fast-forward a dirty root checkout merely to make the integration branch current.
+
+## Phase 6: Attack cross-track boundaries
+
+After all lanes integrate, deliberately test interactions isolated reviewers could not see:
+
+- New UI against hardened backend validation.
+- Search freshness after every newly introduced canonical mutation.
+- Audit/event atomicity around all state transitions.
+- Lease ownership immediately before canonical writes and terminal transitions.
+- Crash recovery at every publish/outbox/journal seam.
+- Old schema/legacy data against new readers and writers.
+- Sanitized/public views against private internal state.
+- Idempotent retry after ambiguous network or process failure.
+- Symlink, path replacement, hardlink, descriptor, and DNS-rebinding edges where relevant.
+- Small-viewport, keyboard, focus, reduced-motion, and screen-reader contracts.
+- Packaging/entry points versus commands used by release evidence.
+
+Spawn focused hardening lanes for real findings. Treat them as release blockers and repeat dual review and integration; do not bury them as “follow-ups.”
+
+## Phase 7: Run the exact final gate
+
+Freeze an exact integration revision. Run the repository’s complete applicable matrix from [references/acceptance-gates.md](references/acceptance-gates.md). Record command, revision, environment, exit code, result counts, and artifact paths.
+
+Then spawn at least two fresh whole-branch reviewers against that exact revision:
+
+- One reviews the complete dossier and approved specifications issue by issue.
+- One reviews engineering, security, privacy, durability, and maintainability across the merged architecture.
+
+Add a runtime/browser reviewer when the user authorized deployment or live verification. Any code change after final review invalidates clearance: freeze a new revision, rerun affected gates, and re-review the delta or whole branch according to risk.
+
+Validate the ledger before reporting completion:
+
+```bash
+python3 <skill-dir>/scripts/fleet_ledger.py validate \
+  --ledger .codex/fleet-runs/<run-id>/ledger.json \
+  --strict
+```
+
+## Phase 8: Deploy or hand off safely
+
+Deployment is a separate state from code clearance.
+
+- If the protected/root checkout is clean and deployment is authorized, move the reviewed revision into place non-destructively, run smoke checks, and record the deployed revision.
+- If it is dirty or owned by another process/person, leave the integration branch intact and report the safe handoff path and exact revision.
+- Before restarting a process, prove the old process and target, check active jobs, preserve unrelated services, and verify restart safety.
+- Never claim live closure from fixture-only evidence.
+
+## Phase 9: Report with calibrated truth
+
+Lead with the exact outcome and revision. Report:
+
+- Issues cleared, partial, blocked, residual, roadmap, and operationally unmeasured.
+- Integrated branch/worktree and whether the root/protected branch was updated.
+- Exact quality matrix and counts.
+- Major implementation results grouped by capability.
+- Important adversarial findings discovered and fixed during review.
+- Live-system actions taken or deliberately not taken.
+- Concurrent work preserved.
+- Actual agent/model usage and substitutions.
+- Remaining deployment, production-scale, performance, or model-level risks.
+
+Distinguish these terms rigorously:
+
+- **Implemented:** code exists.
+- **Fixture-verified:** automated evidence passes.
+- **Independently cleared:** both review axes pass.
+- **Integrated:** present in the combined branch.
+- **Certified:** exact integrated revision passed the final matrix and whole-branch reviews.
+- **Deployed:** that exact certified revision is running.
+- **Production-validated:** representative live measurements meet declared thresholds.
+
+Never collapse them into “done.”
+
+## Completion condition
+
+Stop only when every ledger issue is in a terminal truth state, the integration branch is clean, all required gates for the claimed state pass, final reviewers evaluated the exact revision, deployment status is explicit, and the final report can be regenerated from recorded evidence.

--- a/run-monkey-test-fleet/agents/openai.yaml
+++ b/run-monkey-test-fleet/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Monkey-Test Fleet Orchestrator"
+  short_description: "Turn adversarial findings into verified fixes"
+  default_prompt: "Use $run-monkey-test-fleet to triage this monkey-test dossier, run parallel implementation and independent review fleets, integrate every cleared fix, and produce evidence-backed closure."

--- a/run-monkey-test-fleet/references/acceptance-gates.md
+++ b/run-monkey-test-fleet/references/acceptance-gates.md
@@ -1,0 +1,104 @@
+# Acceptance Gates
+
+## Contents
+
+1. Gate philosophy
+2. Baseline gate
+3. Lane gate
+4. Integration gate
+5. Final code gate
+6. Runtime and production gates
+7. Evidence matrix
+
+## 1. Gate philosophy
+
+Select commands from repository instructions and manifests; do not invent a fashionable matrix that the project does not support. A skipped unavailable gate is `unmeasured`, not `pass`. Record exact commands and revisions.
+
+## 2. Baseline gate
+
+Before implementation, capture:
+
+- Repository status, branch, revision, and dirty paths.
+- Supported interpreter/runtime and dependency environment.
+- Existing unit/integration tests relevant to the dossier.
+- Existing lint, format, type, compile, and package checks.
+- Read-only state of live processes and data.
+- Pre-existing failures with reproduction.
+
+## 3. Lane gate
+
+Each implementation lane should pass:
+
+- Targeted regression tests.
+- Tests for adjacent public behavior.
+- Repository lint/format on touched files.
+- Type checks on touched modules when supported.
+- Security/accessibility/concurrency/crash probes required by its acceptance criteria.
+- Clean branch diff and committed work.
+- Clear specification review.
+- Clear engineering review.
+
+## 4. Integration gate
+
+After every semantic merge wave:
+
+- Run targeted cross-surface tests.
+- Run the full automated suite when affordable.
+- Re-run lint/format/type checks affected by conflict resolution.
+- Compile or syntax-check shipped languages.
+- Check migrations and old-data fixtures.
+- Check for conflict markers, dropped entry points, duplicate handlers, stale tests, and lost documentation.
+- Verify the integrated commit contains every cleared lane commit or equivalent semantic changes.
+
+## 5. Final code gate
+
+Apply all supported items:
+
+- Unit and integration test suites.
+- End-to-end/composed release fixture.
+- Lint and format verification.
+- Static type analysis with zero unwaived errors.
+- Python/module compilation or equivalent.
+- JavaScript/TypeScript syntax and import resolution.
+- Native builds where shipped.
+- Wheel/package/container/application builds.
+- Dependency/entry-point smoke checks.
+- Diff hygiene, conflict-marker, generated-file, and repository-status checks.
+- Security, privacy, durability, recovery, concurrency, and stale-worker adversarial tests.
+- Browser responsive and accessibility checks when UI changed.
+- Two fresh whole-branch reviews of the exact revision.
+
+Record the combined matrix as gate kind `final`, the dossier/spec auditor as `final_spec_review`, and the engineering/security auditor as `final_engineering_review`. All three must pass at the exact integration revision for strict ledger validation.
+
+If a formatter changes code after tests, rerun affected tests and reviews. If the final revision changes, the previous certification no longer names the deployed artifact.
+
+## 6. Runtime and production gates
+
+Keep these separate from code certification:
+
+- Safe deployment of the exact certified revision.
+- Process restart verification.
+- Browser/API/MCP smoke probes.
+- Sanitization and policy probes against live configuration.
+- Representative data coverage.
+- Performance percentiles.
+- Precision/recall/ranking quality.
+- Long-running recovery behavior.
+- Production-scale terminal coverage.
+
+Only run authorized probes. Report fixture-verified but undeployed work accurately.
+
+## 7. Evidence matrix
+
+| Claim | Minimum evidence |
+|---|---|
+| Implemented | Commit and source diff |
+| Regression fixed | Pre-fix reproduction plus post-fix targeted test |
+| Specification-clear | Independent issue-by-issue review |
+| Engineering-clear | Independent adversarial review |
+| Integrated | Combined commit and cross-surface tests |
+| Certified | Exact revision, full supported matrix, final audits |
+| Deployed | Runtime identifies exact certified revision |
+| Production-validated | Representative live metrics meet declared thresholds |
+
+Never use a weaker row to claim a stronger row.

--- a/run-monkey-test-fleet/references/failure-playbook.md
+++ b/run-monkey-test-fleet/references/failure-playbook.md
@@ -1,0 +1,111 @@
+# Failure Playbook
+
+## Contents
+
+1. Unsupported model or tool
+2. Agent failure and weak delivery
+3. Worktree and branch mistakes
+4. Semantic merge collisions
+5. Dirty root or concurrent `main`
+6. Late specifications and expanding scope
+7. Live processes and data
+8. False-green tests
+9. Review disagreement
+10. Exhaustion and blockers
+
+## 1. Unsupported model or tool
+
+If a requested model fails before work begins:
+
+1. Record the exact unsupported response.
+2. Confirm no filesystem changes occurred.
+3. Reassign with the strongest available suitable model.
+4. Preserve independent implementation/review agents.
+5. Disclose the substitution; never use the requested model's name as a nickname for another model.
+
+If repository-required discovery tooling is unavailable, document that condition and use the permitted fallback.
+
+## 2. Agent failure and weak delivery
+
+Treat these as incomplete:
+
+- Memo without code when implementation was assigned.
+- Green tests from an unsupported interpreter.
+- Uncommitted changes without a stable revision.
+- “Done” without issue-to-evidence mapping.
+- Work outside the owned surface without justification.
+
+Inspect the worktree, preserve useful work, tighten the task with exact commands and acceptance criteria, then reassign or follow up. Record agent error separately from lane status.
+
+## 3. Worktree and branch mistakes
+
+If an agent edits the wrong checkout:
+
+1. Stop the lane.
+2. Inspect status and commits in both intended and actual worktrees.
+3. Do not reset or delete changes.
+4. Classify changes as user-owned, concurrent-owner, useful lane work, or off-scope.
+5. Move only committed, attributable work through merge/cherry-pick into the isolated branch.
+6. Reassign with an explicit workspace guard.
+
+## 4. Semantic merge collisions
+
+Do not settle complex conflicts by choosing “ours” or “theirs” globally. State both contracts, assign an integration owner, ask advisers about independent backend/frontend/test dimensions when useful, remove obsolete behavior deliberately, and run combined tests. A syntactically resolved merge is not a semantically correct merge.
+
+## 5. Dirty root or concurrent `main`
+
+Preserve all uncommitted and untracked work. Do not stash, stage, commit, reset, or overwrite it unless the user explicitly authorizes ownership.
+
+- Continue in an isolated integration worktree.
+- Merge newly committed protected-branch work into integration.
+- Re-run affected gates and reviews.
+- Hand off the clean integration branch if the root remains dirty.
+- Explain why root deployment/fast-forward was withheld.
+
+## 6. Late specifications and expanding scope
+
+When a more authoritative approved brief appears:
+
+1. Read it fully.
+2. Compare it with the implemented contract.
+3. Create new findings for material gaps.
+4. Do not retroactively claim earlier agents ignored a document they could not access.
+5. Implement and review the authoritative contract.
+6. Preserve compatible prior hardening.
+
+When concurrent committed features arrive, treat their integration defects as real release findings if they fall within the claimed release artifact. Keep unrelated uncommitted work out.
+
+## 7. Live processes and data
+
+Before any restart or live probe:
+
+- Identify the exact process, command, owner, port, revision, active job, and dependent services.
+- Wait for or preserve active work unless interruption was authorized.
+- Restart only the intended component.
+- Do not infer that a process belongs to this run from its port alone.
+- Keep read-only status probes separate from mutations.
+
+If safe deployment is blocked, code certification may still complete; report deployment as not performed.
+
+## 8. False-green tests
+
+Investigate when tests pass but reviewers find contradictions. Common causes:
+
+- Tests encode retired behavior.
+- Isolated branch lacks another lane's security contract.
+- Fixture does not drive the public path.
+- Evidence generator reports configured rather than measured results.
+- Read paths mutate state unnoticed.
+- Crash windows, lease loss, or ambiguous retry are untested.
+- Accessibility assertions do not reflect real browser focus/layout.
+- Static mocks hide descriptor, path, process, or network behavior.
+
+Add the smallest realistic reproduction and keep the reviewer finding open until it passes on integration.
+
+## 9. Review disagreement
+
+Do not vote. Compare each claim to the authoritative specification and executable evidence. A specification reviewer may clear product behavior while an engineering reviewer finds a security edge; both findings remain valid. Ask a focused third reviewer only when the evidence or governing contract is genuinely ambiguous.
+
+## 10. Exhaustion and blockers
+
+Do not call work blocked because it is large or because one agent failed. Reassign, reduce lanes, integrate sequentially, or use focused advisers. Mark blocked only when required authority, external state, unavailable infrastructure, or a user decision prevents meaningful progress after safe alternatives are exhausted. Record the precise unblock condition.

--- a/run-monkey-test-fleet/references/ledger-schema.md
+++ b/run-monkey-test-fleet/references/ledger-schema.md
@@ -1,0 +1,142 @@
+# Fleet Ledger Schema
+
+## Contents
+
+1. Run state
+2. Issue state machine
+3. Lane state machine
+4. Evidence rules
+5. Minimal example
+
+## 1. Run state
+
+`ledger.json` is the authoritative program record. Required top-level keys:
+
+- `schema_version`: currently `1`.
+- `run`: identity, repository, dossier, base revision, integration revision, deployment revision, status, timestamps, authority, protected paths, and live-process notes.
+- `issues`: normalized findings.
+- `lanes`: ownership and agent status.
+- `gates`: baseline, lane, integration, final, packaging, browser, runtime, and production measurements.
+- `discoveries`: requirements found after initial intake.
+- `residuals`: accepted or unresolved risks.
+- `events`: concise chronological decisions.
+
+Recommended run statuses are `intake`, `planning`, `implementing`, `reviewing`, `rework`, `reconciling`, `integrating`, `final_review`, `certified`, `deployed`, and `complete_with_residuals`. Strict validation accepts only the last three and checks their supporting revision evidence.
+
+Do not store secrets, lease tokens, raw credentials, private source paths intended for public artifacts, or unnecessary process details.
+
+## 2. Issue state machine
+
+Allowed issue states:
+
+```text
+identified -> normalized -> assigned -> implementing -> review_spec
+          -> review_engineering -> rework -> integration_ready -> integrated
+          -> final_review -> cleared
+```
+
+Terminal truth states:
+
+- `cleared`: all required code, evidence, reviews, integration, and documentation are complete.
+- `partial`: some acceptance criteria pass; missing criteria are explicit.
+- `blocked`: external authority/dependency prevents completion after safe alternatives are exhausted.
+- `roadmap`: explicitly out-of-scope capability, not a disguised defect closure.
+- `unmeasured`: implementation may exist, but required production/runtime measurement did not occur.
+- `wont_fix`: user-authorized decision with rationale and risk owner.
+
+An issue may return from either review or integration to `rework`. Any post-clearance code change affecting its surface returns it to `final_review`.
+
+Each issue contains:
+
+```json
+{
+  "id": "AREA-001",
+  "title": "Observable title",
+  "source": "docs/qa/findings.md#area-001",
+  "severity": "P1",
+  "kind": "code",
+  "state": "normalized",
+  "acceptance": [
+    {"id": "AREA-001-A", "criterion": "Observable outcome", "status": "pending", "evidence": []}
+  ],
+  "lane": "area-core",
+  "implementation_commits": [],
+  "reviews": {"spec": [], "engineering": []},
+  "integration_commit": null,
+  "residuals": [],
+  "notes": []
+}
+```
+
+Allowed acceptance statuses: `pending`, `pass`, `fail`, `unmeasured`, `not_applicable`.
+
+## 3. Lane state machine
+
+Allowed lane states:
+
+```text
+planned -> running -> committed -> reviewing -> rework -> cleared
+        -> integrating -> integrated -> final_review -> complete
+```
+
+Failure states are `errored` and `blocked`; they must include a reason and next action. An errored agent does not imply an errored lane if reassigned.
+
+Each lane records:
+
+- ID, issue IDs, owned surfaces, forbidden surfaces.
+- Worktree, branch, base, implementation agent, and reviewer agents.
+- State, commits, command results, findings, rework rounds, and integration notes.
+- Model requested, model actually used, and substitution reason.
+
+## 4. Evidence rules
+
+Every evidence item should contain:
+
+- `kind`: test, review, browser, static-analysis, build, manual-probe, runtime, artifact, or decision.
+- `revision`: exact commit where applicable.
+- `command` or method.
+- `result`: pass, fail, or unmeasured.
+- `summary`: counts or observed behavior.
+- `artifact`: optional repository-relative or run-directory path.
+- `timestamp`.
+
+Clearance requires:
+
+- Every acceptance criterion is `pass` or justified `not_applicable`.
+- At least one implementation commit.
+- A clear specification review.
+- A clear engineering review.
+- An integration commit containing the fix.
+- Relevant combined and final gates at that integration revision or a descendant proven not to alter the surface.
+- No unresolved P0/P1 residual attached to the issue.
+
+Strict run validation also requires at least one issue and lane, terminal lane states, a passing `final` matrix gate, and passing `final_spec_review` and `final_engineering_review` gates at the exact `run.integration_revision`. A run marked `deployed` must name that same revision in `run.deployment_revision`.
+
+Do not count a review statement as test evidence or a unit test as live evidence.
+
+## 5. Minimal example
+
+```json
+{
+  "schema_version": 1,
+  "run": {
+    "id": "2026-08-13-monkey",
+    "repo_root": "/workspace/project",
+    "dossier": "docs/qa/monkey.md",
+    "base_revision": "abc123",
+    "integration_revision": null,
+    "deployment_revision": null,
+    "status": "intake",
+    "created_at": "2026-08-13T00:00:00Z",
+    "authority": ["code_changes"],
+    "protected_paths": [],
+    "live_process_notes": []
+  },
+  "issues": [],
+  "lanes": [],
+  "gates": [],
+  "discoveries": [],
+  "residuals": [],
+  "events": []
+}
+```

--- a/run-monkey-test-fleet/references/orchestration-contract.md
+++ b/run-monkey-test-fleet/references/orchestration-contract.md
@@ -1,0 +1,154 @@
+# Orchestration Contract
+
+## Contents
+
+1. Root responsibilities
+2. Fleet sizing
+3. Agent role contracts
+4. Prompt templates
+5. Review independence
+6. Status protocol
+
+## 1. Root responsibilities
+
+The root orchestrator owns decisions that cannot be safely delegated:
+
+- Scope and authority.
+- Source-of-truth specifications.
+- Issue normalization and acceptance criteria.
+- Lane partitioning and file ownership.
+- Protected branch, dirty-worktree, and live-process safety.
+- Integration order and semantic conflict resolution.
+- Ledger truth.
+- Final revision freeze, quality matrix, and release claim.
+
+Agents may discover facts and propose decisions. They do not independently broaden scope, deploy, overwrite user work, or declare the program complete.
+
+## 2. Fleet sizing
+
+Choose the smallest fleet that exposes real parallelism:
+
+- 1–5 issues in one subsystem: one implementation owner plus two reviewers.
+- 6–20 issues across several subsystems: 3–8 owners plus reviewers launched as commits land.
+- 20+ cross-cutting findings: 6–15 ownership lanes, staged review waves, dedicated integration owners, and fresh final auditors.
+
+Reserve at least 25% of available concurrency for rework, integration, and final audit. Prefer cohesive ownership over maximal agent count. Do not create two owners for the same writable file unless they use isolated worktrees and a named integration owner.
+
+## 3. Agent role contracts
+
+### Implementation owner
+
+Must receive:
+
+- Exact issue IDs and source documents.
+- Explicit owned modules/files and forbidden surfaces.
+- Worktree, branch, and base revision.
+- Baseline and required verification commands.
+- Acceptance criteria and expected evidence.
+- Instruction that other agents are editing the repository and their work must not be reverted.
+- Instruction to avoid live data and unrelated cleanup.
+
+Must return:
+
+- Commit hash.
+- Issues addressed and acceptance mapping.
+- Changed files.
+- Tests added and commands/results.
+- Known gaps and residuals.
+- Integration dependencies/conflicts.
+
+### Specification reviewer
+
+Must not be the implementation owner. Verify exact behavior against the dossier and authoritative specifications. Read source and execute targeted reproductions. Treat missing product behavior, UX contracts, migrations, and public API semantics as findings even when tests pass.
+
+### Engineering reviewer
+
+Must not be the implementation owner or specification reviewer for the same lane when capacity permits. Review failure atomicity, concurrency, stale ownership, validation, privacy, path safety, schema evolution, type contracts, accessibility, maintainability, and test adequacy.
+
+### Integration owner
+
+Own only the named semantic merge in the isolated integration worktree. Preserve both parent contracts, remove obsolete branches deliberately, update tests to the surviving specification, and run combined gates. Do not change unrelated code.
+
+### Final whole-branch auditor
+
+Review an immutable revision with the complete raw dossier/specification set. Do not rely on lane summaries. Seek cross-track defects and verify claims from artifacts or commands.
+
+## 4. Prompt templates
+
+### Implementation prompt
+
+```text
+You own <lane> in worktree <path>, branch <branch>, based on <revision>.
+Issues: <IDs>. Authoritative sources: <paths>.
+Owned surfaces: <files/modules>. Do not edit <forbidden surfaces> without reporting the need.
+
+You are not alone in the codebase. Other agents are editing other branches/worktrees. Do not revert or overwrite their work; adapt to shared contracts and report integration dependencies.
+
+Read all repository instructions. Reproduce the issue, add regressions where practical, implement the smallest complete contract, and run: <commands>. Do not mutate live data/processes or perform unrelated cleanup. Commit your work.
+
+Return: commit, changed files, issue-by-issue acceptance evidence, commands/results, residuals, and expected merge conflicts. A design memo without implementation is not completion.
+```
+
+### Specification-review prompt
+
+```text
+Independently review exact revision <commit> for issues <IDs> against <raw source paths>.
+Do not assume the implementation owner's claims are correct. Inspect code, tests, and public behavior; run targeted reproductions. Return one verdict per issue: clear, partial, fail, or unmeasured. For every finding give severity, location, observable contradiction, and required correction. Do not modify code.
+```
+
+### Engineering-review prompt
+
+```text
+Independently review exact revision <commit> and diff <base>..<commit>.
+Inspect correctness, security, privacy, durability, atomicity, recovery, concurrency, stale-worker fencing, input/path safety, schema compatibility, type safety, accessibility, maintainability, and test quality. Run focused checks. Return prioritized findings with file/function, reproduction or reasoning, and required correction. State whether the lane is safe to integrate. Do not modify code.
+```
+
+### Rework prompt
+
+```text
+Your prior lane at <commit> received the attached independent findings: <findings>.
+Reproduce each finding, patch only the owned surface, add regression evidence, rerun the required gates, and commit a focused follow-up. Return a finding-to-fix map. Do not treat unrelated reviewer suggestions as authorized scope.
+```
+
+### Semantic-integration prompt
+
+```text
+In integration worktree <path>, semantically integrate <commits/branches> onto <base>.
+Preserve contract A: <A>. Preserve contract B: <B>. Retire only these obsolete behaviors: <list>.
+You are not alone in the repository; do not touch the root checkout or unrelated changes. Resolve conflicts, run <combined gates>, commit the merge, and return conflict decisions plus evidence.
+```
+
+### Final audit prompt
+
+```text
+Audit immutable revision <commit> in <worktree> against the complete dossier/spec set <paths>.
+Reconstruct truth from source artifacts, not prior summaries. Verify issue closure, cross-track behavior, quality artifacts, and residual claims. Do not modify code. Return blockers, non-blocking residuals, unmeasured gates, and a release verdict.
+```
+
+## 5. Review independence
+
+Preserve independence by:
+
+- Using separate agents and fresh prompts.
+- Passing raw artifacts and exact revisions.
+- Omitting the intended verdict.
+- Avoiding prior reviewer conclusions unless asking for a focused delta review.
+- Requiring executable or source-based evidence.
+- Re-reviewing after any material fix.
+
+Two agents repeating the implementer's summary are not two reviews.
+
+## 6. Status protocol
+
+Maintain one ledger entry per issue and one lane record per owner. Agent conversational status is advisory until reconciled with commits, diffs, and commands.
+
+Send user updates when:
+
+- Baseline and fleet shape are known.
+- A lane commits and enters review.
+- Review finds a material blocker.
+- A merge wave clears.
+- Final gates start or fail.
+- Live-system safety changes the deployment plan.
+
+State counts and exact blockers. Avoid narrating every tool call.

--- a/run-monkey-test-fleet/scripts/fleet_ledger.py
+++ b/run-monkey-test-fleet/scripts/fleet_ledger.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Initialize, validate, and summarize a monkey-test fleet run ledger."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ISSUE_STATES = {
+    "identified",
+    "normalized",
+    "assigned",
+    "implementing",
+    "review_spec",
+    "review_engineering",
+    "rework",
+    "integration_ready",
+    "integrated",
+    "final_review",
+    "cleared",
+    "partial",
+    "blocked",
+    "roadmap",
+    "unmeasured",
+    "wont_fix",
+}
+TERMINAL_STATES = {
+    "cleared",
+    "partial",
+    "blocked",
+    "roadmap",
+    "unmeasured",
+    "wont_fix",
+}
+LANE_STATES = {
+    "planned",
+    "running",
+    "committed",
+    "reviewing",
+    "rework",
+    "cleared",
+    "integrating",
+    "integrated",
+    "final_review",
+    "complete",
+    "errored",
+    "blocked",
+}
+ACCEPTANCE_STATES = {"pending", "pass", "fail", "unmeasured", "not_applicable"}
+REVIEW_VERDICTS = {"clear", "partial", "fail", "unmeasured"}
+GATE_RESULTS = {"pass", "fail", "unmeasured", "not_applicable"}
+
+
+def utc_now() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"ledger does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"invalid JSON at {path}:{exc.lineno}:{exc.colno}: {exc.msg}"
+        ) from exc
+    if not isinstance(value, dict):
+        raise TypeError("ledger root must be a JSON object")
+    return value
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+    )
+
+
+def init_ledger(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).expanduser().resolve()
+    run_dir.mkdir(parents=True, exist_ok=False)
+    ledger_path = run_dir / "ledger.json"
+    run_id = args.run_id or run_dir.name
+    ledger: dict[str, Any] = {
+        "schema_version": 1,
+        "run": {
+            "id": run_id,
+            "repo_root": str(Path(args.repo_root).expanduser().resolve()),
+            "dossier": args.dossier,
+            "base_revision": args.base_revision,
+            "integration_revision": None,
+            "deployment_revision": None,
+            "status": "intake",
+            "created_at": utc_now(),
+            "authority": [],
+            "protected_paths": [],
+            "live_process_notes": [],
+        },
+        "issues": [],
+        "lanes": [],
+        "gates": [],
+        "discoveries": [],
+        "residuals": [],
+        "events": [
+            {
+                "timestamp": utc_now(),
+                "kind": "run_initialized",
+                "summary": "Fleet ledger initialized",
+            }
+        ],
+    }
+    write_json(ledger_path, ledger)
+    print(ledger_path)
+    return 0
+
+
+def require_list(value: Any, name: str, errors: list[str]) -> list[Any]:
+    if not isinstance(value, list):
+        errors.append(f"{name} must be a list")
+        return []
+    return value
+
+
+def clear_review(reviews: Any, axis: str) -> bool:
+    if not isinstance(reviews, dict):
+        return False
+    records = reviews.get(axis)
+    if not isinstance(records, list):
+        return False
+    return any(
+        isinstance(record, dict) and record.get("verdict") == "clear"
+        for record in records
+    )
+
+
+def validate_ledger(data: dict[str, Any], strict: bool) -> list[str]:
+    errors: list[str] = []
+    if data.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+
+    run = data.get("run")
+    if not isinstance(run, dict):
+        errors.append("run must be an object")
+        run = {}
+    for field in (
+        "id",
+        "repo_root",
+        "dossier",
+        "base_revision",
+        "status",
+        "created_at",
+    ):
+        if not run.get(field):
+            errors.append(f"run.{field} is required")
+
+    issues = require_list(data.get("issues"), "issues", errors)
+    lanes = require_list(data.get("lanes"), "lanes", errors)
+    gates = require_list(data.get("gates"), "gates", errors)
+    require_list(data.get("discoveries"), "discoveries", errors)
+    require_list(data.get("residuals"), "residuals", errors)
+    require_list(data.get("events"), "events", errors)
+
+    issue_ids: set[str] = set()
+    for index, issue in enumerate(issues):
+        prefix = f"issues[{index}]"
+        if not isinstance(issue, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        issue_id = issue.get("id")
+        if not isinstance(issue_id, str) or not issue_id:
+            errors.append(f"{prefix}.id is required")
+        elif issue_id in issue_ids:
+            errors.append(f"duplicate issue id: {issue_id}")
+        else:
+            issue_ids.add(issue_id)
+        if not issue.get("title"):
+            errors.append(f"{prefix}.title is required")
+        state = issue.get("state")
+        if state not in ISSUE_STATES:
+            errors.append(f"{prefix}.state has invalid value: {state!r}")
+        acceptance = require_list(
+            issue.get("acceptance"), f"{prefix}.acceptance", errors
+        )
+        acceptance_ids: set[str] = set()
+        for criterion_index, criterion in enumerate(acceptance):
+            criterion_prefix = f"{prefix}.acceptance[{criterion_index}]"
+            if not isinstance(criterion, dict):
+                errors.append(f"{criterion_prefix} must be an object")
+                continue
+            criterion_id = criterion.get("id")
+            if not criterion_id:
+                errors.append(f"{criterion_prefix}.id is required")
+            elif criterion_id in acceptance_ids:
+                errors.append(f"duplicate acceptance id in {issue_id}: {criterion_id}")
+            else:
+                acceptance_ids.add(str(criterion_id))
+            if not criterion.get("criterion"):
+                errors.append(f"{criterion_prefix}.criterion is required")
+            if criterion.get("status") not in ACCEPTANCE_STATES:
+                errors.append(f"{criterion_prefix}.status is invalid")
+            evidence = criterion.get("evidence")
+            if not isinstance(evidence, list):
+                errors.append(f"{criterion_prefix}.evidence must be a list")
+            if strict and criterion.get("status") == "pass" and not evidence:
+                errors.append(f"{criterion_prefix} passes without evidence")
+
+        reviews = issue.get("reviews")
+        if not isinstance(reviews, dict):
+            errors.append(f"{prefix}.reviews must be an object")
+            reviews = {}
+        for axis in ("spec", "engineering"):
+            records = reviews.get(axis)
+            if not isinstance(records, list):
+                errors.append(f"{prefix}.reviews.{axis} must be a list")
+                continue
+            for review_index, review in enumerate(records):
+                if not isinstance(review, dict):
+                    errors.append(
+                        f"{prefix}.reviews.{axis}[{review_index}] must be an object"
+                    )
+                elif review.get("verdict") not in REVIEW_VERDICTS:
+                    errors.append(
+                        f"{prefix}.reviews.{axis}[{review_index}].verdict is invalid"
+                    )
+
+        if state == "cleared":
+            nonpassing = [
+                criterion.get("id")
+                for criterion in acceptance
+                if isinstance(criterion, dict)
+                and criterion.get("status") not in {"pass", "not_applicable"}
+            ]
+            if nonpassing:
+                errors.append(
+                    f"{issue_id} is cleared with non-passing acceptance: {nonpassing}"
+                )
+            commits = issue.get("implementation_commits")
+            if not isinstance(commits, list) or not commits:
+                errors.append(f"{issue_id} is cleared without implementation_commits")
+            if not clear_review(reviews, "spec"):
+                errors.append(f"{issue_id} is cleared without a clear spec review")
+            if not clear_review(reviews, "engineering"):
+                errors.append(
+                    f"{issue_id} is cleared without a clear engineering review"
+                )
+            if not issue.get("integration_commit"):
+                errors.append(f"{issue_id} is cleared without integration_commit")
+        if strict and state in TERMINAL_STATES - {"cleared"}:
+            residuals = issue.get("residuals")
+            notes = issue.get("notes")
+            if not residuals and not notes:
+                errors.append(
+                    f"{issue_id} is {state} without a recorded rationale or residual"
+                )
+        if strict and state not in TERMINAL_STATES:
+            errors.append(f"{issue_id} is non-terminal in strict mode: {state}")
+
+    lane_ids: set[str] = set()
+    for index, lane in enumerate(lanes):
+        prefix = f"lanes[{index}]"
+        if not isinstance(lane, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        lane_id = lane.get("id")
+        if not isinstance(lane_id, str) or not lane_id:
+            errors.append(f"{prefix}.id is required")
+        elif lane_id in lane_ids:
+            errors.append(f"duplicate lane id: {lane_id}")
+        else:
+            lane_ids.add(lane_id)
+        if lane.get("state") not in LANE_STATES:
+            errors.append(f"{prefix}.state is invalid")
+        lane_issue_ids = require_list(
+            lane.get("issue_ids"), f"{prefix}.issue_ids", errors
+        )
+        for issue_id in lane_issue_ids:
+            if issue_id not in issue_ids:
+                errors.append(f"{prefix} references unknown issue: {issue_id}")
+
+    for index, issue in enumerate(issues):
+        if not isinstance(issue, dict):
+            continue
+        lane_id = issue.get("lane")
+        if lane_id and lane_id not in lane_ids:
+            errors.append(f"issues[{index}] references unknown lane: {lane_id}")
+        if strict and not lane_id:
+            errors.append(f"issues[{index}] has no ownership lane in strict mode")
+
+    for index, gate in enumerate(gates):
+        prefix = f"gates[{index}]"
+        if not isinstance(gate, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        for field in ("id", "kind", "result"):
+            if not gate.get(field):
+                errors.append(f"{prefix}.{field} is required")
+        if gate.get("result") not in GATE_RESULTS:
+            errors.append(f"{prefix}.result is invalid")
+        if strict and gate.get("result") == "pass" and not gate.get("revision"):
+            errors.append(f"{prefix} passes without an exact revision")
+
+    if strict:
+        if not issues:
+            errors.append("strict mode requires at least one normalized issue")
+        if not lanes:
+            errors.append("strict mode requires at least one ownership lane")
+        for index, lane in enumerate(lanes):
+            if isinstance(lane, dict) and lane.get("state") not in {
+                "complete",
+                "blocked",
+            }:
+                errors.append(
+                    f"lanes[{index}] is non-terminal in strict mode: {lane.get('state')}"
+                )
+        if not run.get("integration_revision"):
+            errors.append("strict mode requires run.integration_revision")
+        if run.get("status") not in {
+            "certified",
+            "deployed",
+            "complete_with_residuals",
+        }:
+            errors.append("strict mode requires a terminal truthful run.status")
+        final_pass = any(
+            isinstance(gate, dict)
+            and gate.get("kind") == "final"
+            and gate.get("result") == "pass"
+            and gate.get("revision") == run.get("integration_revision")
+            for gate in gates
+        )
+        if not final_pass:
+            errors.append(
+                "strict mode requires a passing final gate at integration_revision"
+            )
+        for review_kind in ("final_spec_review", "final_engineering_review"):
+            review_pass = any(
+                isinstance(gate, dict)
+                and gate.get("kind") == review_kind
+                and gate.get("result") == "pass"
+                and gate.get("revision") == run.get("integration_revision")
+                for gate in gates
+            )
+            if not review_pass:
+                errors.append(
+                    f"strict mode requires a passing {review_kind} gate at integration_revision"
+                )
+        if run.get("status") == "deployed" and run.get(
+            "deployment_revision"
+        ) != run.get("integration_revision"):
+            errors.append(
+                "a deployed run must deploy the exact certified integration_revision"
+            )
+
+    return errors
+
+
+def validate_command(args: argparse.Namespace) -> int:
+    ledger_path = Path(args.ledger).expanduser().resolve()
+    try:
+        data = load_json(ledger_path)
+        errors = validate_ledger(data, args.strict)
+    except (TypeError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        print(f"Validation failed with {len(errors)} error(s).", file=sys.stderr)
+        return 1
+    print(f"Valid ledger: {ledger_path}")
+    return 0
+
+
+def status_command(args: argparse.Namespace) -> int:
+    ledger_path = Path(args.ledger).expanduser().resolve()
+    try:
+        data = load_json(ledger_path)
+    except (TypeError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    issues = data.get("issues") if isinstance(data.get("issues"), list) else []
+    counts: dict[str, int] = {}
+    for issue in issues:
+        state = issue.get("state", "invalid") if isinstance(issue, dict) else "invalid"
+        counts[state] = counts.get(state, 0) + 1
+    run = data.get("run") if isinstance(data.get("run"), dict) else {}
+    print(f"Run: {run.get('id', '<unknown>')}")
+    print(f"Status: {run.get('status', '<unknown>')}")
+    print(f"Base: {run.get('base_revision', '<unknown>')}")
+    print(f"Integration: {run.get('integration_revision') or '<none>'}")
+    print(f"Deployment: {run.get('deployment_revision') or '<none>'}")
+    print(f"Issues: {len(issues)}")
+    for state in sorted(counts):
+        print(f"  {state}: {counts[state]}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="create a new fleet run ledger")
+    init_parser.add_argument("--run-dir", required=True)
+    init_parser.add_argument("--repo-root", required=True)
+    init_parser.add_argument("--dossier", required=True)
+    init_parser.add_argument("--base-revision", required=True)
+    init_parser.add_argument("--run-id")
+    init_parser.set_defaults(func=init_ledger)
+
+    validate_parser = subparsers.add_parser(
+        "validate", help="validate a fleet run ledger"
+    )
+    validate_parser.add_argument("--ledger", required=True)
+    validate_parser.add_argument("--strict", action="store_true")
+    validate_parser.set_defaults(func=validate_command)
+
+    status_parser = subparsers.add_parser("status", help="print issue-state counts")
+    status_parser.add_argument("--ledger", required=True)
+    status_parser.set_defaults(func=status_command)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- add the `run-monkey-test-fleet` orchestration skill
- define independent implementation, specification-review, engineering-review, integration, and final-audit roles
- add acceptance, failure-recovery, and evidence-ledger references
- add an executable ledger initializer, validator, and status reporter
- update the active `SKILL.md` count to 114

## Why

This packages the repeatable process used to turn large monkey-test and adversarial-QA dossiers into safely parallelized, independently reviewed, semantically integrated, evidence-backed fixes without overwriting concurrent work or overstating deployment and production validation.

## Validation

- skill structure validation
- Ruff lint and format verification
- strict validation of a synthetic certified fleet ledger
- active skill-count verification
- Git diff hygiene
- two independent forward-test scenarios covering initial fleet intake and late-stage concurrent-change/specification reconciliation
